### PR TITLE
Typos 1

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -377,7 +377,7 @@ void DumpBudgets()
             return;
         }
     }
-    LogPrintf("Writting info to budget.dat...\n");
+    LogPrintf("Writing info to budget.dat...\n");
     budgetdb.Write(budget);
 
     LogPrintf("Budget dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -167,7 +167,7 @@ void DumpMasternodePayments()
             return;
         }
     }
-    LogPrintf("Writting info to mnpayments.dat...\n");
+    LogPrintf("Writing info to mnpayments.dat...\n");
     paymentdb.Write(masternodePayments);
 
     LogPrintf("Budget dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -186,7 +186,7 @@ void DumpMasternodes()
             return;
         }
     }
-    LogPrintf("Writting info to mncache.dat...\n");
+    LogPrintf("Writing info to mncache.dat...\n");
     mndb.Write(mnodeman);
 
     LogPrintf("Masternode dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/qt/forms/tradingdialog.ui
+++ b/src/qt/forms/tradingdialog.ui
@@ -123,7 +123,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>4</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="OrderBook">
         <attribute name="title">
@@ -470,7 +470,7 @@
            <x>21</x>
            <y>11</y>
            <width>251</width>
-           <height>20</height>
+           <height>19</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -939,7 +939,7 @@
            <x>11</x>
            <y>301</y>
            <width>269</width>
-           <height>20</height>
+           <height>19</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -1614,7 +1614,7 @@
            <x>22</x>
            <y>12</y>
            <width>258</width>
-           <height>20</height>
+           <height>19</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
@@ -2083,7 +2083,7 @@
            <x>10</x>
            <y>300</y>
            <width>278</width>
-           <height>20</height>
+           <height>19</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -2631,7 +2631,7 @@
           </font>
          </property>
          <property name="text">
-          <string>BTC Balance</string>
+          <string>BTC Balance:</string>
          </property>
         </widget>
         <widget class="QLabel" name="KOREAvailableLabel_2">

--- a/src/qt/forms/tradingdialog.ui
+++ b/src/qt/forms/tradingdialog.ui
@@ -123,7 +123,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>4</number>
        </property>
        <widget class="QWidget" name="OrderBook">
         <attribute name="title">
@@ -375,7 +375,7 @@
           </rect>
          </property>
          <property name="text">
-          <string>KORE</string>
+          <string>BTC</string>
          </property>
         </widget>
         <widget class="QLabel" name="label_6">
@@ -470,7 +470,7 @@
            <x>21</x>
            <y>11</y>
            <width>251</width>
-           <height>19</height>
+           <height>20</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -483,7 +483,7 @@
              </font>
             </property>
             <property name="text">
-             <string>KORE Available:</string>
+             <string>BTC Available:</string>
             </property>
            </widget>
           </item>
@@ -927,7 +927,7 @@
              </font>
             </property>
             <property name="text">
-             <string>KORE</string>
+             <string>BTC</string>
             </property>
            </widget>
           </item>
@@ -939,7 +939,7 @@
            <x>11</x>
            <y>301</y>
            <width>269</width>
-           <height>19</height>
+           <height>20</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -1399,7 +1399,7 @@
              </font>
             </property>
             <property name="text">
-             <string>KORE</string>
+             <string>BTC</string>
             </property>
            </widget>
           </item>
@@ -1436,7 +1436,7 @@
           </rect>
          </property>
          <property name="text">
-          <string>KORE</string>
+          <string>BTC</string>
          </property>
         </widget>
         <widget class="QComboBox" name="SellBidcomboBox">
@@ -1614,7 +1614,7 @@
            <x>22</x>
            <y>12</y>
            <width>258</width>
-           <height>19</height>
+           <height>20</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
@@ -2083,7 +2083,7 @@
            <x>10</x>
            <y>300</y>
            <width>278</width>
-           <height>19</height>
+           <height>20</height>
           </rect>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -2543,7 +2543,7 @@
              </font>
             </property>
             <property name="text">
-             <string> KORE</string>
+             <string>BTC</string>
             </property>
            </widget>
           </item>
@@ -2631,7 +2631,7 @@
           </font>
          </property>
          <property name="text">
-          <string>KORE Balance:</string>
+          <string>BTC Balance</string>
          </property>
         </widget>
         <widget class="QLabel" name="KOREAvailableLabel_2">
@@ -2714,7 +2714,7 @@
           </font>
          </property>
          <property name="text">
-          <string>KORE Available:</string>
+          <string>BTC Available:</string>
          </property>
         </widget>
         <widget class="QLabel" name="CodexAvailableLabel">
@@ -2746,7 +2746,7 @@
           </font>
          </property>
          <property name="text">
-          <string>KORE Pending:</string>
+          <string>BTC Pending:</string>
          </property>
         </widget>
         <widget class="QLabel" name="CodexPendingLabel">

--- a/src/qt/tradingdialog.cpp
+++ b/src/qt/tradingdialog.cpp
@@ -687,7 +687,7 @@ void tradingDialog::ActionsOnSwitch(int index = -1)
         Response = GetBalance("KORE");
 
         if (Response.size() > 0 && Response != "Error") {
-            DisplayBalance(*ui->KOREBalanceLabel, *ui->KOREAvailableLabel, *ui->KOREPendingLabel, QString::fromUtf8("KORE"), Response);
+            DisplayBalance(*ui->KOREBalanceLabel, *ui->KOREAvailableLabel_2, *ui->KOREPendingLabel, QString::fromUtf8("KORE"), Response);
         }
         break;
 

--- a/src/qt/tradingdialog.cpp
+++ b/src/qt/tradingdialog.cpp
@@ -27,7 +27,7 @@
 using namespace boost::xpressive;
 using namespace std;
 
-//Coinbase API, latest BTC orice
+//Coinbase API, latest BTC price
 const QString apiCoinbasePrice = "https://www.bitstamp.net/api/ticker/";
 
 //Bittrex API
@@ -807,7 +807,7 @@ void tradingDialog::on_UpdateKeys_clicked()
     if (ResponseObject.value("success").toBool() == false)
 
     {
-        QMessageBox::information(this, "API Configuration Failed", "Api configuration was unsuccesful.");
+        QMessageBox::information(this, "API Configuration Failed", "Api configuration was unsuccessful.");
 
     } else if (ResponseObject.value("success").toBool() == true) {
         QMessageBox::information(this, "API Configuration Complete", "Api connection has been successfully configured and tested.");


### PR DESCRIPTION
Sorry there are four commits here instead of just one; I started off with some simple typos and then before I worked out the right way to submit a pull request to a project forked off a common ancestor decided to fix some of the labels on some of the trading tabs. Doing so with (Qt) designer introduced a few spurious (invisible) changes which are reverted in the fourth commit. There is one actual code change (included in the third commit): the balances tab was writing the KORE balance into the wrong field.   